### PR TITLE
Create Lockout Timer

### DIFF
--- a/Assets/Scripts/Ghost.cs
+++ b/Assets/Scripts/Ghost.cs
@@ -13,6 +13,8 @@ public class Ghost : MonoBehaviour
     public Vector3Int[] cells;
     public Vector3Int position;
 
+    private float lockoutTimer = 1f;
+
     private void Awake()
     {
         tilemap = GetComponentInChildren<Tilemap>();
@@ -25,6 +27,20 @@ public class Ghost : MonoBehaviour
         Copy();
         Drop();
         Set();
+        TestLockout();
+    }
+
+    private void TestLockout()
+    {
+        if (position == trackingPiece.position)
+        {
+            lockoutTimer -= Time.deltaTime;
+        }
+        if (lockoutTimer <= 0)
+        {
+            lockoutTimer = 1f;
+            trackingPiece.ForceLock();
+        }
     }
 
     private void Clear()

--- a/Assets/Scripts/Piece.cs
+++ b/Assets/Scripts/Piece.cs
@@ -109,6 +109,12 @@ public class Piece : MonoBehaviour
         }
     }
 
+    public void ForceLock() //Called by the ghost when it ends the timer for the tracked piece
+    {
+        Move(Vector2Int.down);
+        Lock();
+    }
+
     private bool Move(Vector2Int translation)
     {
         Vector3Int newPosition = position;


### PR DESCRIPTION
Each frame, if the Ghost sees that it and the piece it tracks have the same position, a 1 second timer is decremented by the frame time. Once the timer hits zero, the piece is locked into position, with a downshift to compensate for any kicks.