### PR TITLE
Add Banana/Pickup Spawning (Also Fixed Ghost Bug)

### DIFF
--- a/Assets/Data/10,20 BoardData.asset
+++ b/Assets/Data/10,20 BoardData.asset
@@ -12,3 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 18dc77b241490494388a9713cd8c6311, type: 3}
   m_Name: 10,20 BoardData
   m_EditorClassIdentifier: 
+  pickupXRange: {x: -5, y: 4}
+  pickupYRange: {x: -8, y: 2}

--- a/Assets/Data/10,20 BoardData.asset
+++ b/Assets/Data/10,20 BoardData.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18dc77b241490494388a9713cd8c6311, type: 3}
+  m_Name: 10,20 BoardData
+  m_EditorClassIdentifier: 

--- a/Assets/Data/10,20 BoardData.asset.meta
+++ b/Assets/Data/10,20 BoardData.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b6c1767adb548ee4cb0246685a24ed37
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SinglePlayerScene.unity
+++ b/Assets/Scenes/SinglePlayerScene.unity
@@ -801,6 +801,10 @@ PrefabInstance:
       propertyPath: m_Size.x
       value: 10
       objectReference: {fileID: 0}
+    - target: {fileID: 1169076175916197968, guid: c7ad593dedbf8d943aa4f48606fbd64d, type: 3}
+      propertyPath: m_Size.y
+      value: 20
+      objectReference: {fileID: 0}
     - target: {fileID: 1169076176437697654, guid: c7ad593dedbf8d943aa4f48606fbd64d, type: 3}
       propertyPath: ghost
       value: 
@@ -863,6 +867,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1169076176437697654, guid: c7ad593dedbf8d943aa4f48606fbd64d, type: 3}
       propertyPath: pickups.Array.data[0].cells.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1169076177254229124, guid: c7ad593dedbf8d943aa4f48606fbd64d, type: 3}
+      propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1169076177740018797, guid: c7ad593dedbf8d943aa4f48606fbd64d, type: 3}

--- a/Assets/Scenes/SinglePlayerScene.unity
+++ b/Assets/Scenes/SinglePlayerScene.unity
@@ -625,6 +625,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   board: {fileID: 264470866}
+  Score: {x: 0, y: 0}
 --- !u!4 &1956594308
 Transform:
   m_ObjectHideFlags: 0
@@ -796,6 +797,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1169076175916197968, guid: c7ad593dedbf8d943aa4f48606fbd64d, type: 3}
+      propertyPath: m_Size.x
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 1169076176437697654, guid: c7ad593dedbf8d943aa4f48606fbd64d, type: 3}
       propertyPath: ghost
       value: 
@@ -803,6 +808,10 @@ PrefabInstance:
     - target: {fileID: 1169076176437697654, guid: c7ad593dedbf8d943aa4f48606fbd64d, type: 3}
       propertyPath: activePiece
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1169076176437697654, guid: c7ad593dedbf8d943aa4f48606fbd64d, type: 3}
+      propertyPath: pickups.Array.size
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1169076176437697654, guid: c7ad593dedbf8d943aa4f48606fbd64d, type: 3}
       propertyPath: PieceList.Array.size
@@ -824,6 +833,10 @@ PrefabInstance:
       propertyPath: ControlDataList.Array.size
       value: 2
       objectReference: {fileID: 0}
+    - target: {fileID: 1169076176437697654, guid: c7ad593dedbf8d943aa4f48606fbd64d, type: 3}
+      propertyPath: pickups.Array.data[0].tile
+      value: 
+      objectReference: {fileID: 11400000, guid: b0c4b75a3c56f2d44991f06d94565e50, type: 2}
     - target: {fileID: 1169076176437697654, guid: c7ad593dedbf8d943aa4f48606fbd64d, type: 3}
       propertyPath: playerColors.Array.data[0]
       value: 
@@ -847,6 +860,10 @@ PrefabInstance:
     - target: {fileID: 1169076176437697654, guid: c7ad593dedbf8d943aa4f48606fbd64d, type: 3}
       propertyPath: tetrominos.Array.data[0].tetromino
       value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1169076176437697654, guid: c7ad593dedbf8d943aa4f48606fbd64d, type: 3}
+      propertyPath: pickups.Array.data[0].cells.Array.size
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1169076177740018797, guid: c7ad593dedbf8d943aa4f48606fbd64d, type: 3}
       propertyPath: m_Name

--- a/Assets/Scenes/SinglePlayerScene.unity
+++ b/Assets/Scenes/SinglePlayerScene.unity
@@ -814,6 +814,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 0}
     - target: {fileID: 1169076176437697654, guid: c7ad593dedbf8d943aa4f48606fbd64d, type: 3}
+      propertyPath: boardSizeData
+      value: 
+      objectReference: {fileID: 11400000, guid: b6c1767adb548ee4cb0246685a24ed37, type: 2}
+    - target: {fileID: 1169076176437697654, guid: c7ad593dedbf8d943aa4f48606fbd64d, type: 3}
       propertyPath: pickups.Array.size
       value: 1
       objectReference: {fileID: 0}

--- a/Assets/Scripts/Board.cs
+++ b/Assets/Scripts/Board.cs
@@ -16,6 +16,7 @@ public class Board : MonoBehaviour
     public Ghost ghost;
     public GameManager gameManager;
     public List<Tile> playerColors = new List<Tile>();
+    public BoardSizeSO boardSizeData;
     public RectInt Bounds
     {
         get
@@ -44,7 +45,7 @@ public class Board : MonoBehaviour
         activePiece.Initialize(this, spawnPosition, data);
         Set(activePiece);
         //SpawnPickups();
-        SpawnPickup();
+        SpawnPickups();
     }
 
     public void SpawnPiece()
@@ -58,7 +59,7 @@ public class Board : MonoBehaviour
         activePiece.Initialize(this, spawnPosition , data);
         ghost.trackingPiece = activePiece;
 
-        if (!IsValidPosition(activePiece, spawnPosition))
+        if (!IsValidPosition(activePiece.cells, spawnPosition))
         {
             GameOver();
             SpawnPiece(); // Makes Winner Start The Next Round
@@ -92,12 +93,12 @@ public class Board : MonoBehaviour
         }
     }
 
-    public bool IsValidPosition(Piece piece, Vector3Int position)
+    public bool IsValidPosition(Vector3Int[] cells, Vector3Int position)
     {
         // Checks If All Cells Would Be Valid After Move
-        for (int i = 0; i < piece.cells.Length; i++)
+        for (int i = 0; i < cells.Length; i++)
         {
-            Vector3Int tilePosition = piece.cells[i] + position;
+            Vector3Int tilePosition = cells[i] + position;
 
             if (!Bounds.Contains((Vector2Int)tilePosition))
             {
@@ -189,7 +190,7 @@ public class Board : MonoBehaviour
 
     public void SpawnPickups()
     {
-        int bananaAmount = Random.Range(0, 5);
+        int bananaAmount = Random.Range(1, 4);
         Debug.Log(bananaAmount);
         for (int i = 0; i < bananaAmount; i++)
         {
@@ -201,12 +202,25 @@ public class Board : MonoBehaviour
     {
         Pickup pickup = new();
         PickupData data = pickups[Random.Range(0, pickups.Length)];
-        //Vector3Int pickupSpawn = new Vector3Int(Random.Range(-5, 5), Random.Range(9, -9), 0);
+        bool FreePosition = true;
+        do
+        {
+            // -5 X  Left 4 X Right  9 Y Top -10 Y Bottom For Default 10/20 Board
+            Vector3Int pickupSpawn = new Vector3Int(Random.Range(boardSizeData.pickupXRange.x, boardSizeData.pickupXRange.y),
+                Random.Range(boardSizeData.pickupYRange.x, boardSizeData.pickupYRange.y), 0);
+            pickup.Initialize(pickupSpawn, data);
 
-        // -5 X  Left 4 X Right  9 Y Top -10 Y Bottom
-        Vector3Int pickupSpawn = new Vector3Int(4, -10, 0);
-        Debug.Log(pickupSpawn);
-        pickup.Initialize(pickupSpawn, data);
+            if(!IsValidPosition(pickup.cells, pickupSpawn))
+            {
+                // Not Free Spot
+                FreePosition = false;
+            }
+            else
+            {
+                // Free Spot
+                FreePosition = true;
+            }
+        } while (!FreePosition);
 
         //Vector3Int tilePosition = pickup.cells + pickup.position;
 

--- a/Assets/Scripts/Board.cs
+++ b/Assets/Scripts/Board.cs
@@ -43,7 +43,8 @@ public class Board : MonoBehaviour
         data.tile = playerColors[0];
         activePiece.Initialize(this, spawnPosition, data);
         Set(activePiece);
-        SpawnPickups();
+        //SpawnPickups();
+        SpawnPickup();
     }
 
     public void SpawnPiece()
@@ -192,19 +193,27 @@ public class Board : MonoBehaviour
         Debug.Log(bananaAmount);
         for (int i = 0; i < bananaAmount; i++)
         {
-            Pickup pickup = new();
-            PickupData data = pickups[Random.Range(0, pickups.Length)];
-            Vector3Int pickupSpawn = new Vector3Int(Random.Range(-5, 5), Random.Range(9, -9), 0);
-            Debug.Log(pickupSpawn);
-            pickup.Initialize(pickupSpawn, data);
+            SpawnPickup();
+        }
+    }
 
-            //Vector3Int tilePosition = pickup.cells + pickup.position;
+    public void SpawnPickup()
+    {
+        Pickup pickup = new();
+        PickupData data = pickups[Random.Range(0, pickups.Length)];
+        //Vector3Int pickupSpawn = new Vector3Int(Random.Range(-5, 5), Random.Range(9, -9), 0);
 
-            for (int cell = 0; cell < pickup.cells.Length; cell++)
-            {
-                Vector3Int tilePosition = pickup.cells[cell] + pickup.position;
-                tilemap.SetTile(tilePosition, pickup.data.tile);
-            }
+        // -5 X  Left 4 X Right  9 Y Top -10 Y Bottom
+        Vector3Int pickupSpawn = new Vector3Int(4, -10, 0);
+        Debug.Log(pickupSpawn);
+        pickup.Initialize(pickupSpawn, data);
+
+        //Vector3Int tilePosition = pickup.cells + pickup.position;
+
+        for (int cell = 0; cell < pickup.cells.Length; cell++)
+        {
+            Vector3Int tilePosition = pickup.cells[cell] + pickup.position;
+            tilemap.SetTile(tilePosition, pickup.data.tile);
         }
     }
 

--- a/Assets/Scripts/Board.cs
+++ b/Assets/Scripts/Board.cs
@@ -108,7 +108,7 @@ public class Board : MonoBehaviour
             if (tilemap.HasTile(tilePosition))
             {
                 // Checks If Tile Already Present If So Cant Move There, Therefore False Unless Its A Pickup
-                if (CheckPickup) // The Check
+                if (CheckPickup) // The CheckPickup Bool Is Used To Make Sure Only The Player Piece Can Trigger The Pickup
                 {
                     return CheckForPickUp(tilePosition);
                 }
@@ -131,7 +131,7 @@ public class Board : MonoBehaviour
         {
             case "Yellow": // Banana Tile
                 tilemap.SetTile(tilePosition, null);
-                gameManager.BannaCollected(PieceIndex);
+                gameManager.BananaCollected(PieceIndex);
                 return true;
 
             default: // Normal Tile

--- a/Assets/Scripts/Board.cs
+++ b/Assets/Scripts/Board.cs
@@ -10,7 +10,7 @@ public class Board : MonoBehaviour
     public List<PlayerControls> ControlDataList = new List<PlayerControls>();
     public int PieceIndex = 0;
     public TetrominoData[] tetrominos;
-    public List<PickupData> pickupsList = new List<PickupData>();
+    public PickupData[] pickups;
     public Vector3Int spawnPosition;
     public Vector2Int boardSize = new Vector2Int(10, 20);
     public Ghost ghost;
@@ -27,7 +27,6 @@ public class Board : MonoBehaviour
     private void Awake()
     {
         tilemap = GetComponentInChildren<Tilemap>();
-
         activePiece = GetComponentInChildren<Piece>();
         activePiece.pieceControls = ControlDataList[0];
         ghost.trackingPiece = activePiece;
@@ -44,6 +43,7 @@ public class Board : MonoBehaviour
         data.tile = playerColors[0];
         activePiece.Initialize(this, spawnPosition, data);
         Set(activePiece);
+        SpawnPickups();
     }
 
     public void SpawnPiece()
@@ -115,22 +115,22 @@ public class Board : MonoBehaviour
         return true;
     }
 
-    public void CheckForPickUp(Piece piece, Vector3Int position)
-    {
-        Vector3Int tilePosition = piece.cells[i] + position;
-        TileBase tileBase = tilemap.GetTile(tilePosition);
-        switch (tileBase.name)
-        {
-            case "Banana":
-                tilemap.SetTile(tilePosition, null);
-                gameManager.BannaCollected(PieceIndex);
-                break;
+    //public void CheckForPickUp(Piece piece, Vector3Int position)
+    ////{
+    ////    Vector3Int tilePosition = piece.cells[i] + position;
+    ////    TileBase tileBase = tilemap.GetTile(tilePosition);
+    ////    switch (tileBase.name)
+    ////    {
+    ////        case "Banana":
+    ////            tilemap.SetTile(tilePosition, null);
+    ////            gameManager.BannaCollected(PieceIndex);
+    ////            break;
 
-            default:
+    ////        default:
 
-                break;
-        }
-    }
+    ////            break;
+    ////    }
+    ////}
 
     //public void ClearLines()
     //{
@@ -188,20 +188,24 @@ public class Board : MonoBehaviour
 
     public void SpawnPickups()
     {
+        int bananaAmount = Random.Range(0, 5);
+        Debug.Log(bananaAmount);
+        for (int i = 0; i < bananaAmount; i++)
+        {
+            Pickup pickup = new();
+            PickupData data = pickups[Random.Range(0, pickups.Length)];
+            Vector3Int pickupSpawn = new Vector3Int(Random.Range(-5, 5), Random.Range(9, -9), 0);
+            Debug.Log(pickupSpawn);
+            pickup.Initialize(pickupSpawn, data);
 
-        //do
-        //{
-        //    Vector3Int PickupSpawnPosition = new Vector3Int(Random.Range(0, boardSize.x), Random.Range(0, boardSize.y), 0);
-        //    PickupData data = pickupsList[Random.Range(0, pickupsList.Count)];
+            //Vector3Int tilePosition = pickup.cells + pickup.position;
 
-        //    if (IsValidPosition(activePiece, PickupSpawnPosition))
-        //    {
-        //        return;
-        //    }
-        //} while ()
-        
-
-        Set(activePiece);
+            for (int cell = 0; cell < pickup.cells.Length; cell++)
+            {
+                Vector3Int tilePosition = pickup.cells[cell] + pickup.position;
+                tilemap.SetTile(tilePosition, pickup.data.tile);
+            }
+        }
     }
 
 }

--- a/Assets/Scripts/Board.cs
+++ b/Assets/Scripts/Board.cs
@@ -44,7 +44,6 @@ public class Board : MonoBehaviour
         data.tile = playerColors[0];
         activePiece.Initialize(this, spawnPosition, data);
         Set(activePiece);
-        //SpawnPickups();
         SpawnPickups();
     }
 
@@ -59,7 +58,7 @@ public class Board : MonoBehaviour
         activePiece.Initialize(this, spawnPosition , data);
         ghost.trackingPiece = activePiece;
 
-        if (!IsValidPosition(activePiece.cells, spawnPosition))
+        if (!IsValidPosition(activePiece.cells, spawnPosition, true))
         {
             GameOver();
             SpawnPiece(); // Makes Winner Start The Next Round
@@ -93,7 +92,7 @@ public class Board : MonoBehaviour
         }
     }
 
-    public bool IsValidPosition(Vector3Int[] cells, Vector3Int position)
+    public bool IsValidPosition(Vector3Int[] cells, Vector3Int position, bool CheckPickup)
     {
         // Checks If All Cells Would Be Valid After Move
         for (int i = 0; i < cells.Length; i++)
@@ -108,8 +107,15 @@ public class Board : MonoBehaviour
 
             if (tilemap.HasTile(tilePosition))
             {
-                // Checks If Tile Already Present If So Cant Move There, Therefore False
-                return false;
+                // Checks If Tile Already Present If So Cant Move There, Therefore False Unless Its A Pickup
+                if (CheckPickup) // The Check
+                {
+                    return CheckForPickUp(tilePosition);
+                }
+                else
+                {
+                    return false;
+                }
             }
         }
 
@@ -117,22 +123,21 @@ public class Board : MonoBehaviour
         return true;
     }
 
-    //public void CheckForPickUp(Piece piece, Vector3Int position)
-    ////{
-    ////    Vector3Int tilePosition = piece.cells[i] + position;
-    ////    TileBase tileBase = tilemap.GetTile(tilePosition);
-    ////    switch (tileBase.name)
-    ////    {
-    ////        case "Banana":
-    ////            tilemap.SetTile(tilePosition, null);
-    ////            gameManager.BannaCollected(PieceIndex);
-    ////            break;
+    public bool CheckForPickUp(Vector3Int tilePosition)
+    {
+        // Checks If Tile Is One Of The Pickup Tiles, If Pickup, Triggers Their Effect
+        TileBase tileBase = tilemap.GetTile(tilePosition);
+        switch (tileBase.name)
+        {
+            case "Yellow": // Banana Tile
+                tilemap.SetTile(tilePosition, null);
+                gameManager.BannaCollected(PieceIndex);
+                return true;
 
-    ////        default:
-
-    ////            break;
-    ////    }
-    ////}
+            default: // Normal Tile
+                return false;
+        }
+    }
 
     //public void ClearLines()
     //{
@@ -191,7 +196,6 @@ public class Board : MonoBehaviour
     public void SpawnPickups()
     {
         int bananaAmount = Random.Range(1, 4);
-        Debug.Log(bananaAmount);
         for (int i = 0; i < bananaAmount; i++)
         {
             SpawnPickup();
@@ -210,19 +214,8 @@ public class Board : MonoBehaviour
                 Random.Range(boardSizeData.pickupYRange.x, boardSizeData.pickupYRange.y), 0);
             pickup.Initialize(pickupSpawn, data);
 
-            if(!IsValidPosition(pickup.cells, pickupSpawn))
-            {
-                // Not Free Spot
-                FreePosition = false;
-            }
-            else
-            {
-                // Free Spot
-                FreePosition = true;
-            }
+            FreePosition = IsValidPosition(pickup.cells, pickupSpawn, false); // Checks If Pickup Position Is Free
         } while (!FreePosition);
-
-        //Vector3Int tilePosition = pickup.cells + pickup.position;
 
         for (int cell = 0; cell < pickup.cells.Length; cell++)
         {

--- a/Assets/Scripts/Board.cs
+++ b/Assets/Scripts/Board.cs
@@ -107,23 +107,29 @@ public class Board : MonoBehaviour
             if (tilemap.HasTile(tilePosition))
             {
                 // Checks If Tile Already Present If So Cant Move There, Therefore False
-                TileBase tileBase = tilemap.GetTile(tilePosition);
-                switch (tileBase.name)
-                {
-                    case "Banana":
-                        tilemap.SetTile(tilePosition, null);
-                        gameManager.BannaCollected(PieceIndex);
-                        break;
-
-                    default:
-                        // Normal Block
-                        return false;
-                }
+                return false;
             }
         }
 
         // Movement Is Valid
         return true;
+    }
+
+    public void CheckForPickUp(Piece piece, Vector3Int position)
+    {
+        Vector3Int tilePosition = piece.cells[i] + position;
+        TileBase tileBase = tilemap.GetTile(tilePosition);
+        switch (tileBase.name)
+        {
+            case "Banana":
+                tilemap.SetTile(tilePosition, null);
+                gameManager.BannaCollected(PieceIndex);
+                break;
+
+            default:
+
+                break;
+        }
     }
 
     //public void ClearLines()

--- a/Assets/Scripts/Board.cs
+++ b/Assets/Scripts/Board.cs
@@ -10,6 +10,7 @@ public class Board : MonoBehaviour
     public List<PlayerControls> ControlDataList = new List<PlayerControls>();
     public int PieceIndex = 0;
     public TetrominoData[] tetrominos;
+    public List<PickupData> pickupsList = new List<PickupData>();
     public Vector3Int spawnPosition;
     public Vector2Int boardSize = new Vector2Int(10, 20);
     public Ghost ghost;
@@ -106,7 +107,18 @@ public class Board : MonoBehaviour
             if (tilemap.HasTile(tilePosition))
             {
                 // Checks If Tile Already Present If So Cant Move There, Therefore False
-                return false;
+                TileBase tileBase = tilemap.GetTile(tilePosition);
+                switch (tileBase.name)
+                {
+                    case "Banana":
+                        tilemap.SetTile(tilePosition, null);
+                        gameManager.BannaCollected(PieceIndex);
+                        break;
+
+                    default:
+                        // Normal Block
+                        return false;
+                }
             }
         }
 
@@ -166,6 +178,24 @@ public class Board : MonoBehaviour
 
             row++;
         }
+    }
+
+    public void SpawnPickups()
+    {
+
+        //do
+        //{
+        //    Vector3Int PickupSpawnPosition = new Vector3Int(Random.Range(0, boardSize.x), Random.Range(0, boardSize.y), 0);
+        //    PickupData data = pickupsList[Random.Range(0, pickupsList.Count)];
+
+        //    if (IsValidPosition(activePiece, PickupSpawnPosition))
+        //    {
+        //        return;
+        //    }
+        //} while ()
+        
+
+        Set(activePiece);
     }
 
 }

--- a/Assets/Scripts/Board.cs
+++ b/Assets/Scripts/Board.cs
@@ -200,6 +200,7 @@ public class Board : MonoBehaviour
         {
             SpawnPickup();
         }
+        gameManager.bananaAmount = bananaAmount;
     }
 
     public void SpawnPickup()

--- a/Assets/Scripts/Data.cs
+++ b/Assets/Scripts/Data.cs
@@ -22,7 +22,12 @@ public static class Data
         { Tetromino.T, new Vector2Int[] {new Vector2Int( 0, 1), new Vector2Int(-1, 1), new Vector2Int( 1, 1), new Vector2Int( 1, 0), new Vector2Int( -1, 0) } },
     //     { Tetromino.Z, new Vector2Int[] { new Vector2Int( 0, 1), new Vector2Int(-1, 0), new Vector2Int( -1, 1) } },
    };
-  
+
+    public static readonly Dictionary<Pickup, Vector2Int[]> Pickups = new Dictionary<Pickup, Vector2Int[]>()
+    {
+        { Pickup.B, new Vector2Int[] {new Vector2Int( 0, 1) } },
+   };
+
     //private static readonly Vector2Int[,] WallKicksI = new Vector2Int[,] {
     //    { new Vector2Int(0, 0), new Vector2Int(-2, 0), new Vector2Int( 1, 0), new Vector2Int(-2,-1), new Vector2Int( 1, 2) },
     //    { new Vector2Int(0, 0), new Vector2Int( 2, 0), new Vector2Int(-1, 0), new Vector2Int( 2, 1), new Vector2Int(-1,-2) },

--- a/Assets/Scripts/Data.cs
+++ b/Assets/Scripts/Data.cs
@@ -23,9 +23,9 @@ public static class Data
     //     { Tetromino.Z, new Vector2Int[] { new Vector2Int( 0, 1), new Vector2Int(-1, 0), new Vector2Int( -1, 1) } },
    };
 
-    public static readonly Dictionary<Pickup, Vector2Int[]> Pickups = new Dictionary<Pickup, Vector2Int[]>()
+    public static readonly Dictionary<PickupType, Vector2Int[]> Pickups = new Dictionary<PickupType, Vector2Int[]>()
     {
-        { Pickup.B, new Vector2Int[] {new Vector2Int( 0, 1) } },
+        { PickupType.B, new Vector2Int[] {new Vector2Int( 0, 1) } },
    };
 
     //private static readonly Vector2Int[,] WallKicksI = new Vector2Int[,] {

--- a/Assets/Scripts/Data.cs
+++ b/Assets/Scripts/Data.cs
@@ -25,7 +25,7 @@ public static class Data
 
     public static readonly Dictionary<PickupType, Vector2Int[]> Pickups = new Dictionary<PickupType, Vector2Int[]>()
     {
-        { PickupType.B, new Vector2Int[] {new Vector2Int( 0, 1) } },
+        { PickupType.B, new Vector2Int[] {new Vector2Int( 0, 0) } },
    };
 
     //private static readonly Vector2Int[,] WallKicksI = new Vector2Int[,] {

--- a/Assets/Scripts/Ghost.cs
+++ b/Assets/Scripts/Ghost.cs
@@ -16,7 +16,7 @@ public class Ghost : MonoBehaviour
     private void Awake()
     {
         tilemap = GetComponentInChildren<Tilemap>();
-        cells = new Vector3Int[4];
+        cells = new Vector3Int[5];
     }
 
     private void LateUpdate()

--- a/Assets/Scripts/Ghost.cs
+++ b/Assets/Scripts/Ghost.cs
@@ -57,7 +57,7 @@ public class Ghost : MonoBehaviour
         {
             position.y = row;
 
-            if (mainBoard.IsValidPosition(trackingPiece, position))
+            if (mainBoard.IsValidPosition(trackingPiece.cells, position))
             {
                 this.position = position;
             }

--- a/Assets/Scripts/Ghost.cs
+++ b/Assets/Scripts/Ghost.cs
@@ -57,7 +57,7 @@ public class Ghost : MonoBehaviour
         {
             position.y = row;
 
-            if (mainBoard.IsValidPosition(trackingPiece.cells, position))
+            if (mainBoard.IsValidPosition(trackingPiece.cells, position, false))
             {
                 this.position = position;
             }

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -6,6 +6,7 @@ public class GameManager : MonoBehaviour
 {
     private UIManager UIManager;
     public Board board;
+    public Vector2 Score = Vector2.zero;
     private void Awake()
     {
         UIManager = GetComponent<UIManager>();
@@ -19,5 +20,19 @@ public class GameManager : MonoBehaviour
     public void PlayerChange(int PlayerNumber)
     {
         UIManager.PlayerChange(PlayerNumber);
+    }
+
+    public void BannaCollected(int PlayerIndex)
+    {
+        if (PlayerIndex == 0)
+        {
+            //Player One
+            Score.x++;
+        }
+        else
+        {
+            //Player Two
+            Score.y++;
+        }
     }
 }

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -34,5 +34,6 @@ public class GameManager : MonoBehaviour
             //Player Two
             Score.y++;
         }
+        Debug.Log("Score Now Stands At Player One: " + Score.x + " Player Two: " + Score.y);
     }
 }

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -22,8 +22,9 @@ public class GameManager : MonoBehaviour
         UIManager.PlayerChange(PlayerNumber);
     }
 
-    public void BannaCollected(int PlayerIndex)
+    public void BananaCollected(int PlayerIndex)
     {
+        // Player Currently Gets 1 Score Per Banana
         if (PlayerIndex == 0)
         {
             //Player One

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -6,6 +6,7 @@ public class GameManager : MonoBehaviour
 {
     private UIManager UIManager;
     public Board board;
+    public int bananaAmount;
     public Vector2 Score = Vector2.zero;
     private void Awake()
     {
@@ -36,5 +37,11 @@ public class GameManager : MonoBehaviour
             Score.y++;
         }
         Debug.Log("Score Now Stands At Player One: " + Score.x + " Player Two: " + Score.y);
+        bananaAmount--;
+        if (bananaAmount <= 0)
+        {
+            // If All Bananas Are Collected Then Spawn Some More
+            board.SpawnPickups();
+        }
     }
 }

--- a/Assets/Scripts/Pickup.cs
+++ b/Assets/Scripts/Pickup.cs
@@ -1,19 +1,27 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.Tilemaps;
 
-public enum Pickup
+public class Pickup : MonoBehaviour
 {
-    B
-}
-public struct PickupData
-{
-    public Pickup pickUp;
-    public Tile tile;
-    public Vector2Int[] cells;
-    public void Initalize()
+    public Vector3Int[] cells;
+    public PickupData data;
+    public Vector3Int position;
+
+    public void Initialize(Vector3Int position, PickupData data)
     {
-        this.cells = Data.Pickups[pickUp];
+        this.position = position;
+        this.data = data;
+        cells = new Vector3Int[data.cells.Length];
+
+        for (int i = 0; i < data.cells.Length; i++)
+        {
+            cells[i] = (Vector3Int)data.cells[i];
+        }
+    }
+
+    public virtual void PreformEffect()
+    {
+
     }
 }

--- a/Assets/Scripts/Pickup.cs
+++ b/Assets/Scripts/Pickup.cs
@@ -1,0 +1,19 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Tilemaps;
+
+public enum Pickup
+{
+    B
+}
+public struct PickupData
+{
+    public Pickup pickUp;
+    public Tile tile;
+    public Vector2Int[] cells;
+    public void Initalize()
+    {
+        this.cells = Data.Pickups[pickUp];
+    }
+}

--- a/Assets/Scripts/Pickup.cs.meta
+++ b/Assets/Scripts/Pickup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: decd7516d3d781e4eb81aa4ca8e0f6da
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/PickupInfo.cs
+++ b/Assets/Scripts/PickupInfo.cs
@@ -1,0 +1,20 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Tilemaps;
+
+public enum PickupType
+{
+    B
+}
+[System.Serializable]
+public struct PickupData
+{
+    public PickupType pickUp;
+    public Tile tile;
+    public Vector2Int[] cells;
+    public void Initalize()
+    {
+        this.cells = Data.Pickups[pickUp];
+    }
+}

--- a/Assets/Scripts/PickupInfo.cs.meta
+++ b/Assets/Scripts/PickupInfo.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2c80dc6cd0db19a4d8036a5a203bd031
+guid: decd7516d3d781e4eb81aa4ca8e0f6da
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Scripts/Piece.cs
+++ b/Assets/Scripts/Piece.cs
@@ -108,7 +108,7 @@ public class Piece : MonoBehaviour
         newPosition.x += translation.x;
         newPosition.y += translation.y;
 
-        if (board.IsValidPosition(this, newPosition))
+        if (board.IsValidPosition(cells, newPosition))
         {
             position = newPosition;
             lockTime = 0f;

--- a/Assets/Scripts/Piece.cs
+++ b/Assets/Scripts/Piece.cs
@@ -108,7 +108,7 @@ public class Piece : MonoBehaviour
         newPosition.x += translation.x;
         newPosition.y += translation.y;
 
-        if (board.IsValidPosition(cells, newPosition))
+        if (board.IsValidPosition(cells, newPosition, true))
         {
             position = newPosition;
             lockTime = 0f;

--- a/Assets/Scripts/SO/BoardSizeSO.cs
+++ b/Assets/Scripts/SO/BoardSizeSO.cs
@@ -1,0 +1,10 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "NewBoardSizeData", menuName = "Data/BoardSizeData")]
+public class BoardSizeSO : ScriptableObject
+{
+    public Vector2 pickupXRange = new Vector2();
+    public Vector2 pickupYRange = new Vector2();
+}

--- a/Assets/Scripts/SO/BoardSizeSO.cs
+++ b/Assets/Scripts/SO/BoardSizeSO.cs
@@ -5,6 +5,6 @@ using UnityEngine;
 [CreateAssetMenu(fileName = "NewBoardSizeData", menuName = "Data/BoardSizeData")]
 public class BoardSizeSO : ScriptableObject
 {
-    public Vector2 pickupXRange = new Vector2();
-    public Vector2 pickupYRange = new Vector2();
+    public Vector2Int pickupXRange = new Vector2Int();
+    public Vector2Int pickupYRange = new Vector2Int();
 }

--- a/Assets/Scripts/SO/BoardSizeSO.cs
+++ b/Assets/Scripts/SO/BoardSizeSO.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 [CreateAssetMenu(fileName = "NewBoardSizeData", menuName = "Data/BoardSizeData")]
 public class BoardSizeSO : ScriptableObject
 {
-    public Vector2Int pickupXRange = new Vector2Int();
-    public Vector2Int pickupYRange = new Vector2Int();
+    // Holds Data For The Board Size
+    public Vector2Int pickupXRange = new Vector2Int(); // Safe Pickup Spawn Range On The X Axis
+    public Vector2Int pickupYRange = new Vector2Int(); // Safe Pickup Spawn Range On The Y Axis
 }

--- a/Assets/Scripts/SO/BoardSizeSO.cs.meta
+++ b/Assets/Scripts/SO/BoardSizeSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 18dc77b241490494388a9713cd8c6311
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The Actual Functionality Of The Bananas Have Been Left Fairly Plain As The Function Of Them Are To Be Decided On, Today In Class. The Spawning Of The Bananas Is Fairly Good And Should Be Very Extendable To Add Other Types Of Pickups. Created A Scriptable Object To Hold The Data Of The Board Size. This Is Used To Give The Safe Spawn Area For The Pickups. Currently The Pickups Are Triggered When You Move Through Them And The Ghost Piece Treats Them Like Their Not There. These Specific Functions Should Be Discussed In Class Today As It Will Depend On The Game Loop We Decide On For Our Game.